### PR TITLE
custom cell styling

### DIFF
--- a/json-to-table.js
+++ b/json-to-table.js
@@ -105,7 +105,7 @@ function ConvertJsonToTable(parsedJson, tableId, tableClassName, linkText)
 				}
                     		thCon += thRow.format(headerData.data);
 			} else {
-                    		thCon += thRow.format(parsedJson[0][headers[i]]);
+                    		thCon += thRow.format(headers[i]);
 			}
 		}
             }


### PR DESCRIPTION
added some lines to enable passing custom cell styling, e.g., background, font, etc .., this applies to header cells as well as body cells without affecting the old way of setting the JSON table.
A function was appended to the end of the code to help stringify whatever is passed in as 'cell properties'.
