### PR TITLE
jslint compatibility and making use of Object.keys built-in method instead of array_keys

### DIFF
--- a/json-to-table.js
+++ b/json-to-table.js
@@ -1,6 +1,5 @@
 /**
  * JavaScript format string function
- * 
  */
 String.prototype.format = function()
 {
@@ -13,6 +12,40 @@ String.prototype.format = function()
   });
 };
 
+// from: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/keys
+if (!Object.keys) {
+  Object.keys = (function () {
+    var hasOwnProperty = Object.prototype.hasOwnProperty,
+        hasDontEnumBug = !({toString: null}).propertyIsEnumerable('toString'),
+        dontEnums = [
+          'toString',
+          'toLocaleString',
+          'valueOf',
+          'hasOwnProperty',
+          'isPrototypeOf',
+          'propertyIsEnumerable',
+          'constructor'
+        ],
+        dontEnumsLength = dontEnums.length;
+ 
+    return function (obj) {
+      if (typeof obj !== 'object' && typeof obj !== 'function' || obj === null) throw new TypeError('Object.keys called on non-object');
+ 
+      var result = [];
+ 
+      for (var prop in obj) {
+        if (hasOwnProperty.call(obj, prop)) result.push(prop);
+      }
+ 
+      if (hasDontEnumBug) {
+        for (var i=0; i < dontEnumsLength; i++) {
+          if (hasOwnProperty.call(obj, dontEnums[i])) result.push(dontEnums[i]);
+        }
+      }
+      return result;
+    }
+  })()
+};
 
 /**
  * Convert a Javascript Oject array or String array to an HTML table
@@ -83,7 +116,7 @@ function ConvertJsonToTable(parsedJson, tableId, tableClassName, linkText)
             // If JSON data is an object array, headers are automatically computed
             if(typeof(parsedJson[0]) == 'object')
             {
-                headers = array_keys(parsedJson[0]);
+                headers = Object.keys(parsedJson[0]);
 
                 for (i = 0; i < headers.length; i++)
                     thCon += thRow.format(headers[i]);
@@ -143,46 +176,4 @@ function ConvertJsonToTable(parsedJson, tableId, tableClassName, linkText)
         return tbl;
     }
     return null;
-}
-
-
-/**
- * Return just the keys from the input array, optionally only for the specified search_value
- * version: 1109.2015
- *  discuss at: http://phpjs.org/functions/array_keys
- *  +   original by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
- *  +      input by: Brett Zamir (http://brett-zamir.me)
- *  +   bugfixed by: Kevin van Zonneveld (http://kevin.vanzonneveld.net)
- *  +   improved by: jd
- *  +   improved by: Brett Zamir (http://brett-zamir.me)
- *  +   input by: P
- *  +   bugfixed by: Brett Zamir (http://brett-zamir.me)
- *  *     example 1: array_keys( {firstname: 'Kevin', surname: 'van Zonneveld'} );
- *  *     returns 1: {0: 'firstname', 1: 'surname'}
- */
-function array_keys(input, search_value, argStrict)
-{
-    var search = typeof search_value !== 'undefined', tmp_arr = [], strict = !!argStrict, include = true, key = '';
-
-    if (input && typeof input === 'object' && input.change_key_case) { // Duck-type check for our own array()-created PHPJS_Array
-        return input.keys(search_value, argStrict);
-    }
- 
-    for (key in input)
-    {
-        if (input.hasOwnProperty(key))
-        {
-            include = true;
-            if (search)
-            {
-                if (strict && input[key] !== search_value)
-                    include = false;
-                else if (input[key] != search_value)
-                    include = false;
-            } 
-            if (include)
-                tmp_arr[tmp_arr.length] = key;
-        }
-    }
-    return tmp_arr;
 }

--- a/json-to-table.js
+++ b/json-to-table.js
@@ -1,51 +1,59 @@
 /**
  * JavaScript format string function
  */
-String.prototype.format = function()
-{
-  var args = arguments;
+String.prototype.format = function () {
+    "use strict";
+    var args = arguments;
 
-  return this.replace(/{(\d+)}/g, function(match, number)
-  {
-    return typeof args[number] != 'undefined' ? args[number] :
-                                                '{' + number + '}';
-  });
+    return this.replace(/\{(\d+)\}/g, function (match, number) {
+        return args[number] !== undefined ? args[number] :
+                                          '{' + number + '}';
+    });
 };
 
 // from: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/keys
 if (!Object.keys) {
-  Object.keys = (function () {
-    var hasOwnProperty = Object.prototype.hasOwnProperty,
-        hasDontEnumBug = !({toString: null}).propertyIsEnumerable('toString'),
-        dontEnums = [
-          'toString',
-          'toLocaleString',
-          'valueOf',
-          'hasOwnProperty',
-          'isPrototypeOf',
-          'propertyIsEnumerable',
-          'constructor'
-        ],
-        dontEnumsLength = dontEnums.length;
- 
-    return function (obj) {
-      if (typeof obj !== 'object' && typeof obj !== 'function' || obj === null) throw new TypeError('Object.keys called on non-object');
- 
-      var result = [];
- 
-      for (var prop in obj) {
-        if (hasOwnProperty.call(obj, prop)) result.push(prop);
-      }
- 
-      if (hasDontEnumBug) {
-        for (var i=0; i < dontEnumsLength; i++) {
-          if (hasOwnProperty.call(obj, dontEnums[i])) result.push(dontEnums[i]);
-        }
-      }
-      return result;
-    }
-  })()
-};
+    Object.keys = (function () {
+        "use strict";
+        var hasOwnProperty = Object.prototype.hasOwnProperty,
+            hasDontEnumBug = !({toString: null}).propertyIsEnumerable('toString'),
+            dontEnums = [
+                'toString',
+                'toLocaleString',
+                'valueOf',
+                'hasOwnProperty',
+                'isPrototypeOf',
+                'propertyIsEnumerable',
+                'constructor'
+            ],
+            dontEnumsLength = dontEnums.length;
+
+        return function (obj) {
+            var result = [],
+                prop,
+                i;
+
+            if ((typeof obj !== 'object' && typeof obj !== 'function') || obj === null) {
+                throw new TypeError('Object.keys called on non-object');
+            }
+
+            for (prop in obj) {
+                if (obj.hasOwnProperty(prop)) {
+                    result.push(prop);
+                }
+            }
+
+            if (hasDontEnumBug) {
+                for (i = 0; i < dontEnumsLength; i += 1) {
+                    if (hasOwnProperty.call(obj, dontEnums[i])) {
+                        result.push(dontEnums[i]);
+                    }
+                }
+            }
+            return result;
+        };
+    }());
+}
 
 /**
  * Convert a Javascript Oject array or String array to an HTML table
@@ -76,91 +84,82 @@ if (!Object.keys) {
  * 
  * @return string Converted JSON to HTML table
  */
-function ConvertJsonToTable(parsedJson, tableId, tableClassName, linkText)
-{
-    //Patterns for links and NULL value
-    var italic = '<i>{0}</i>';
-    var link = linkText ? '<a href="{0}">' + linkText + '</a>' :
-                          '<a href="{0}">{0}</a>';
+function ConvertJsonToTable(parsedJson, tableId, tableClassName, linkText) {
+    "use strict";
+    if (parsedJson) {
+        var
+            // Patterns for links and NULL value
+            italic = '<i>{0}</i>',
+            link = linkText ? '<a href="{0}">' + linkText + '</a>' :
+                              '<a href="{0}">{0}</a>',
 
-    //Pattern for table                          
-    var idMarkup = tableId ? ' id="' + tableId + '"' :
-                             '';
+            // Pattern for table
+            idMarkup = tableId ? ' id="' + tableId + '"' :
+                                     '',
 
-    var classMarkup = tableClassName ? ' class="' + tableClassName + '"' :
-                                       '';
+            classMarkup = tableClassName ? ' class="' + tableClassName + '"' :
+                                           '',
 
-    var tbl = '<table border="1" cellpadding="1" cellspacing="1"' + idMarkup + classMarkup + '>{0}{1}</table>';
+            tbl = '<table border="1" cellpadding="1" cellspacing="1"' + idMarkup + classMarkup + '>{0}{1}</table>',
 
-    //Patterns for table content
-    var th = '<thead>{0}</thead>';
-    var tb = '<tbody>{0}</tbody>';
-    var tr = '<tr>{0}</tr>';
-    var thRow = '<th>{0}</th>';
-    var tdRow = '<td>{0}</td>';
-    var thCon = '';
-    var tbCon = '';
-    var trCon = '';
+            //Patterns for table content
+            th = '<thead>{0}</thead>',
+            tb = '<tbody>{0}</tbody>',
+            tr = '<tr>{0}</tr>',
+            thRow = '<th>{0}</th>',
+            tdRow = '<td>{0}</td>',
+            thCon = '',
+            tbCon = '',
+            trCon = '',
 
-    if (parsedJson)
-    {
-        var isStringArray = typeof(parsedJson[0]) == 'string';
-        var headers;
+            isStringArray = typeof (parsedJson[0]) === 'string' || parsedJson[0] instanceof String,
+            headers,
+            urlRegExp = new RegExp(/(\b(https?|ftp|file):\/\/[\-A-Z0-9+&@#\/%?=~_|!:,.;]*[\-A-Z0-9+&@#\/%=~_|])/ig),
+            javascriptRegExp = new RegExp(/(^javascript:[\s\S]*;$)/ig),
+            i, j, value, isUrl; // we don't wanna use global variables
 
         // Create table headers from JSON data
         // If JSON data is a simple string array we create a single table header
-        if(isStringArray)
+        if (isStringArray) {
             thCon += thRow.format('value');
-        else
-        {
+        } else {
             // If JSON data is an object array, headers are automatically computed
-            if(typeof(parsedJson[0]) == 'object')
-            {
+            // XXX: what about string objects (new String("foo"))?
+            if (typeof (parsedJson[0]) === 'object') {
                 headers = Object.keys(parsedJson[0]);
 
-                for (i = 0; i < headers.length; i++)
+                for (i = 0; i < headers.length; i += 1) {
                     thCon += thRow.format(headers[i]);
+                }
             }
         }
         th = th.format(tr.format(thCon));
-        
+
         // Create table rows from Json data
-        if(isStringArray)
-        {
-            for (i = 0; i < parsedJson.length; i++)
-            {
+        if (isStringArray) {
+            for (i = 0; i < parsedJson.length; i += 1) {
                 tbCon += tdRow.format(parsedJson[i]);
                 trCon += tr.format(tbCon);
                 tbCon = '';
             }
-        }
-        else
-        {
-            if(headers)
-            {
-                var urlRegExp = new RegExp(/(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/ig);
-                var javascriptRegExp = new RegExp(/(^javascript:[\s\S]*;$)/ig);
-                
-                for (i = 0; i < parsedJson.length; i++)
-                {
-                    for (j = 0; j < headers.length; j++)
-                    {
-                        var value = parsedJson[i][headers[j]];
-                        var isUrl = urlRegExp.test(value) || javascriptRegExp.test(value);
+        } else {
+            if (headers) {
+                for (i = 0; i < parsedJson.length; i += 1) {
+                    for (j = 0; j < headers.length; j += 1) {
+                        value = parsedJson[i][headers[j]];
+                        isUrl = urlRegExp.test(value) || javascriptRegExp.test(value);
 
-                        if(isUrl)   // If value is URL we auto-create a link
+                        if (isUrl) { // If value is URL we auto-create a link
                             tbCon += tdRow.format(link.format(value));
-                        else
-                        {
-                            if(value){
-                            	if(typeof(value) == 'object'){
-                            		//for supporting nested tables
-                            		tbCon += tdRow.format(ConvertJsonToTable(eval(value.data), value.tableId, value.tableClassName, value.linkText));
-                            	} else {
-                            		tbCon += tdRow.format(value);
-                            	}
-                                
-                            } else {    // If value == null we format it like PhpMyAdmin NULL values
+                        } else {
+                            if (value) {
+                                if (typeof (value) === 'object') {
+                                    //for supporting nested tables
+                                    tbCon += tdRow.format(ConvertJsonToTable.call({}, value.data, value.tableId, value.tableClassName, value.linkText));
+                                } else {
+                                    tbCon += tdRow.format(value);
+                                }
+                            } else { // If value == null we format it like PhpMyAdmin NULL values
                                 tbCon += tdRow.format(italic.format(value).toUpperCase());
                             }
                         }


### PR DESCRIPTION
the title describes pretty much everything. for installing jslint use `npm install jslint`. for Object.keys method take a look at https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/keys